### PR TITLE
Load essential groups/packages from PetitParser without breaking pharo in baseline

### DIFF
--- a/BaselineOfOrgMode/BaselineOfOrgMode.class.st
+++ b/BaselineOfOrgMode/BaselineOfOrgMode.class.st
@@ -11,7 +11,7 @@ BaselineOfOrgMode >> baseline: spec [
 	spec for: #common do: [ 
 		spec baseline: 'PetitParser' with: [ 
 			spec
-				loads: #( 'Core' );
+				loads: #( 'Core' 'PetitIndent' );
 				repository: 'github://moosetechnology/PetitParser:v3.x.x/src' ].
 		spec package: 'OrgMode' with: [ spec requires: #( 'PetitParser' ) ].
 		spec

--- a/BaselineOfOrgMode/BaselineOfOrgMode.class.st
+++ b/BaselineOfOrgMode/BaselineOfOrgMode.class.st
@@ -9,10 +9,10 @@ BaselineOfOrgMode >> baseline: spec [
 
 	<baseline>
 	spec for: #common do: [ 
-		spec
-			baseline: 'PetitParser'
-			with: [ 
-			spec repository: 'github://moosetechnology/PetitParser:v3.x.x/src' ].
+		spec baseline: 'PetitParser' with: [ 
+			spec
+				loads: #( 'Core' );
+				repository: 'github://moosetechnology/PetitParser:v3.x.x/src' ].
 		spec package: 'OrgMode' with: [ spec requires: #( 'PetitParser' ) ].
 		spec
 			package: 'OrgMode-Tests'

--- a/BaselineOfOrgMode/BaselineOfOrgMode.class.st
+++ b/BaselineOfOrgMode/BaselineOfOrgMode.class.st
@@ -11,7 +11,7 @@ BaselineOfOrgMode >> baseline: spec [
 	spec for: #common do: [ 
 		spec baseline: 'PetitParser' with: [ 
 			spec
-				loads: #( 'Core' 'PetitIndent' );
+				loads: #( 'Core' 'PetitIndent' 'PetitIslands' );
 				repository: 'github://moosetechnology/PetitParser:v3.x.x/src' ].
 		spec package: 'OrgMode' with: [ spec requires: #( 'PetitParser' ) ].
 		spec


### PR DESCRIPTION
closes #5 
closes #7 